### PR TITLE
U505-038 Drop `with Ada.Interrupts.Names;`

### DIFF
--- a/source/spawn/spawn-processes__glib.adb
+++ b/source/spawn/spawn-processes__glib.adb
@@ -19,8 +19,11 @@
 -- version 3.1, as published by the Free Software Foundation.               --
 ------------------------------------------------------------------------------
 
-with Ada.Interrupts.Names;
 with Interfaces.C;
+
+pragma Warnings (Off, "internal GNAT unit");
+with System.OS_Interface;
+pragma Warnings (On);
 
 with Spawn.Environments.Internal;
 with Spawn.Posix;
@@ -369,7 +372,7 @@ package body Spawn.Processes is
 
       Code : constant Interfaces.C.int := Spawn.Posix.kill
         (Interfaces.C.int (Self.pid),
-         Interfaces.C.int (Ada.Interrupts.Names.SIGKILL));
+         Interfaces.C.int (System.OS_Interface.SIGKILL));
    begin
       pragma Assert (Code = 0);
    end Kill_Process;
@@ -616,7 +619,7 @@ package body Spawn.Processes is
 
       Code : constant Interfaces.C.int := Spawn.Posix.kill
         (Interfaces.C.int (Self.pid),
-         Interfaces.C.int (Ada.Interrupts.Names.SIGTERM));
+         Interfaces.C.int (System.OS_Interface.SIGTERM));
    begin
       pragma Assert (Code = 0);
    end Terminate_Process;

--- a/source/spawn/spawn-processes__posix.adb
+++ b/source/spawn/spawn-processes__posix.adb
@@ -22,7 +22,10 @@
 with Spawn.Processes.Monitor;
 with Spawn.Posix;
 with GNAT.OS_Lib;
-with Ada.Interrupts.Names;
+
+pragma Warnings (Off, "internal GNAT unit");
+with System.OS_Interface;
+pragma Warnings (On);
 
 with Interfaces.C;
 
@@ -126,7 +129,7 @@ package body Spawn.Processes is
 
       Code : constant Interfaces.C.int :=
         Spawn.Posix.kill
-          (Self.pid, Interfaces.C.int (Ada.Interrupts.Names.SIGKILL));
+          (Self.pid, Interfaces.C.int (System.OS_Interface.SIGKILL));
    begin
       pragma Assert (Code = 0);
    end Kill_Process;
@@ -304,7 +307,7 @@ package body Spawn.Processes is
 
       Code : constant Interfaces.C.int :=
         Spawn.Posix.kill
-          (Self.pid, Interfaces.C.int (Ada.Interrupts.Names.SIGTERM));
+          (Self.pid, Interfaces.C.int (System.OS_Interface.SIGTERM));
    begin
       pragma Assert (Code = 0);
    end Terminate_Process;


### PR DESCRIPTION
It breaks GNAT Studio debug facilities by reserving
some signals.