### PR TITLE
Remove unwanted `pragma Unreferenced`

### DIFF
--- a/testsuite/spawn/spawn_kill.adb
+++ b/testsuite/spawn/spawn_kill.adb
@@ -120,7 +120,6 @@ procedure Spawn_Kill is
         (Self          : in out Listener;
          Process_Error : Integer)
       is
-         pragma Unreferenced (Self);
       begin
          Ada.Text_IO.Put_Line ("Error_Occurred:" & (Process_Error'Img));
          Ada.Command_Line.Set_Exit_Status (Ada.Command_Line.Failure);


### PR DESCRIPTION
This pragma causes a compilation error as the library no longer builds
with a recent gnat as the emitted warning is treated as an error.