### PR TITLE
use short circuit operator

### DIFF
--- a/source/spawn/spawn-processes-windows.adb
+++ b/source/spawn/spawn-processes-windows.adb
@@ -357,7 +357,8 @@ package body Spawn.Processes.Windows is
                begin
                   Attempts := Attempts - 1;
 
-                  if Error /= Windows_API.ERROR_PIPE_BUSY or Attempts = 0 then
+                  if Error /= Windows_API.ERROR_PIPE_BUSY or else Attempts = 0
+                  then
                      Self.Listener.Error_Occurred (Integer (Error));
 
                      Interfaces.C.Strings.Free (Pipe_Name);


### PR DESCRIPTION
Dear Spawn Developers,

According to [adaic](https://www.adaic.org/resources/add_content/docs/95style/html/sec_5/5-5-5.html)
one should prefer short circuit operators.

Problem detected and solved by Rejuvenation-Ada crate
[![vote for Rejuvenation-Ada as The 2022 Ada Crate Of The Year](https://user-images.githubusercontent.com/18348654/191469254-1ca1f4a0-6242-43fa-94a2-f39f55817fdc.jpg)](https://github.com/AdaCore/Ada-SPARK-Crate-Of-The-Year/issues/15)